### PR TITLE
rename triggers & activities

### DIFF
--- a/activity/coap/activity.go
+++ b/activity/coap/activity.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	_ = activity.Register(&CoAPActivity{}, New)
+	_ = activity.Register(&Activity{}, New)
 }
 
 var activityMd = activity.ToMetadata(&Settings{}, &Input{}, &Output{})
@@ -41,13 +41,13 @@ func New(ctx activity.InitContext) (activity.Activity, error) {
 		msgType = toCoapMsgType(s.MessageType)
 	}
 
-	return &CoAPActivity{settings: s, msgType: msgType, methodCode: toCoapMethodCode(s.Method), coapURI: coapURI}, nil
+	return &Activity{settings: s, msgType: msgType, methodCode: toCoapMethodCode(s.Method), coapURI: coapURI}, nil
 }
 
-// CoAPActivity is an Activity that is used to send a CoAP message
+// Activity is an Activity that is used to send a CoAP message
 // inputs : {method,type,payload,messageId}
 // outputs: {result}
-type CoAPActivity struct {
+type Activity struct {
 	settings *Settings
 
 	coapURI    *url.URL
@@ -55,14 +55,14 @@ type CoAPActivity struct {
 	methodCode coap.COAPCode
 }
 
-func (act *CoAPActivity) Metadata() *activity.Metadata {
+func (act *Activity) Metadata() *activity.Metadata {
 	return activityMd
 }
 
 //todo enhance CoAP client code
 
 // Eval implements api.Activity.Eval - Invokes a REST Operation
-func (act *CoAPActivity) Eval(ctx activity.Context) (done bool, err error) {
+func (act *Activity) Eval(ctx activity.Context) (done bool, err error) {
 
 	log := ctx.Logger()
 	input := &Input{}

--- a/activity/coap/activity_test.go
+++ b/activity/coap/activity_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRegister(t *testing.T) {
 
-	ref := activity.GetRef(&CoAPActivity{})
+	ref := activity.GetRef(&Activity{})
 	act := activity.Get(ref)
 
 	assert.NotNil(t, act)

--- a/activity/gpio/activity.go
+++ b/activity/gpio/activity.go
@@ -33,14 +33,14 @@ const (
 )
 
 func init() {
-	_ = activity.Register(&GPIOActivity{}, New)
+	_ = activity.Register(&Activity{}, New)
 }
 
-type GPIOActivity struct {
+type Activity struct {
 	settings *Settings
 }
 
-var GPIOActivitymd = activity.ToMetadata(&Settings{}, &Input{}, &Output{})
+var activityMd = activity.ToMetadata(&Settings{}, &Input{}, &Output{})
 
 func New(ctx activity.InitContext) (activity.Activity, error) {
 	s := &Settings{}
@@ -51,15 +51,15 @@ func New(ctx activity.InitContext) (activity.Activity, error) {
 		return nil, err
 	}
 
-	return &GPIOActivity{settings: s}, nil
+	return &Activity{settings: s}, nil
 }
 
-func (a *GPIOActivity) Metadata() *activity.Metadata {
-	return GPIOActivitymd
+func (a *Activity) Metadata() *activity.Metadata {
+	return activityMd
 }
 
 // Eval implements api.Activity.Eval - Invokes a REST Operation
-func (a *GPIOActivity) Eval(ctx activity.Context) (done bool, err error) {
+func (a *Activity) Eval(ctx activity.Context) (done bool, err error) {
 
 	log := ctx.Logger()
 	//getmethod

--- a/activity/gpio/activity_test.go
+++ b/activity/gpio/activity_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRegister(t *testing.T) {
 
-	ref := activity.GetRef(&GPIOActivity{})
+	ref := activity.GetRef(&Activity{})
 	act := activity.Get(ref)
 
 	assert.NotNil(t, act)

--- a/activity/mqtt/activity.go
+++ b/activity/mqtt/activity.go
@@ -12,7 +12,7 @@ import (
 var activityMd = activity.ToMetadata(&Settings{}, &Input{}, &Output{})
 
 func init() {
-	_ = activity.Register(&MqttActivity{}, New)
+	_ = activity.Register(&Activity{}, New)
 }
 
 func New(ctx activity.InitContext) (activity.Activity, error) {
@@ -60,20 +60,20 @@ func New(ctx activity.InitContext) (activity.Activity, error) {
 		return nil, token.Error()
 	}
 
-	act := &MqttActivity{client: mqttClient}
+	act := &Activity{client: mqttClient}
 	return act, nil
 }
 
-type MqttActivity struct {
+type Activity struct {
 	settings *Settings
 	client   mqtt.Client
 }
 
-func (a *MqttActivity) Metadata() *activity.Metadata {
+func (a *Activity) Metadata() *activity.Metadata {
 	return activityMd
 }
 
-func (a *MqttActivity) Eval(ctx activity.Context) (done bool, err error) {
+func (a *Activity) Eval(ctx activity.Context) (done bool, err error) {
 
 	input := &Input{}
 

--- a/activity/mqtt/activity_test.go
+++ b/activity/mqtt/activity_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRegister(t *testing.T) {
 
-	ref := activity.GetRef(&MqttActivity{})
+	ref := activity.GetRef(&Activity{})
 	act := activity.Get(ref)
 
 	assert.NotNil(t, act)

--- a/trigger/coap/trigger.go
+++ b/trigger/coap/trigger.go
@@ -17,7 +17,7 @@ import (
 var triggerMd = trigger.NewMetadata(&Settings{}, &HandlerSettings{}, &Output{})
 
 func init() {
-	_ = trigger.Register(&CoApTrigger{}, &Factory{})
+	_ = trigger.Register(&Trigger{}, &Factory{})
 }
 
 type Factory struct {
@@ -36,11 +36,11 @@ func (*Factory) New(config *trigger.Config) (trigger.Trigger, error) {
 		return nil, err
 	}
 
-	return &CoApTrigger{id: config.Id, settings: s}, nil
+	return &Trigger{id: config.Id, settings: s}, nil
 }
 
 // Trigger CoAp trigger struct
-type CoApTrigger struct {
+type Trigger struct {
 	server    *Server
 	settings  *Settings
 	resources map[string]*CoapResource
@@ -53,7 +53,7 @@ type CoapResource struct {
 	handlers map[coap.COAPCode]trigger.Handler
 }
 
-func (t *CoApTrigger) Initialize(ctx trigger.InitContext) error {
+func (t *Trigger) Initialize(ctx trigger.InitContext) error {
 
 	t.logger = ctx.Logger()
 
@@ -93,16 +93,16 @@ func (t *CoApTrigger) Initialize(ctx trigger.InitContext) error {
 	return nil
 }
 
-func (t *CoApTrigger) Start() error {
+func (t *Trigger) Start() error {
 	return t.server.Start()
 }
 
 // Stop implements util.Managed.Stop
-func (t *CoApTrigger) Stop() error {
+func (t *Trigger) Stop() error {
 	return t.server.Stop()
 }
 
-func newActionHandler(t *CoApTrigger, resource *CoapResource) coap.Handler {
+func newActionHandler(t *Trigger, resource *CoapResource) coap.Handler {
 
 	return coap.FuncHandler(func(conn *net.UDPConn, addr *net.UDPAddr, msg *coap.Message) *coap.Message {
 		t.logger.Debugf("CoAP Trigger: Recieved request")
@@ -177,7 +177,7 @@ func newActionHandler(t *CoApTrigger, resource *CoapResource) coap.Handler {
 	})
 }
 
-func (t *CoApTrigger) handleDiscovery(conn *net.UDPConn, addr *net.UDPAddr, msg *coap.Message) *coap.Message {
+func (t *Trigger) handleDiscovery(conn *net.UDPConn, addr *net.UDPAddr, msg *coap.Message) *coap.Message {
 
 	//todo add filter support
 	if msg.Code == coap.GET {

--- a/trigger/coap/trigger_test.go
+++ b/trigger/coap/trigger_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTrigger_Register(t *testing.T) {
 
-	ref := support.GetRef(&CoApTrigger{})
+	ref := support.GetRef(&Trigger{})
 	f := trigger.GetFactory(ref)
 	assert.NotNil(t, f)
 }

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -16,11 +16,11 @@ import (
 var triggerMd = trigger.NewMetadata(&Settings{}, &HandlerSettings{}, &Output{})
 
 func init() {
-	_ = trigger.Register(&MqttTrigger{}, &Factory{})
+	_ = trigger.Register(&Trigger{}, &Factory{})
 }
 
-// MqttTrigger is simple MQTT trigger
-type MqttTrigger struct {
+// Trigger is simple MQTT trigger
+type Trigger struct {
 	handlers map[string]*clientHandler
 	settings *Settings
 	logger   log.Logger
@@ -48,11 +48,11 @@ func (*Factory) New(config *trigger.Config) (trigger.Trigger, error) {
 		return nil, err
 	}
 
-	return &MqttTrigger{settings: s}, nil
+	return &Trigger{settings: s}, nil
 }
 
 // Initialize implements trigger.Initializable.Initialize
-func (t *MqttTrigger) Initialize(ctx trigger.InitContext) error {
+func (t *Trigger) Initialize(ctx trigger.InitContext) error {
 	t.logger = ctx.Logger()
 
 	settings := t.settings
@@ -173,7 +173,7 @@ func initClientOption(settings *Settings) *mqtt.ClientOptions {
 }
 
 // Start implements trigger.Trigger.Start
-func (t *MqttTrigger) Start() error {
+func (t *Trigger) Start() error {
 
 	client := mqtt.NewClient(t.options)
 
@@ -197,7 +197,7 @@ func (t *MqttTrigger) Start() error {
 }
 
 // Stop implements ext.Trigger.Stop
-func (t *MqttTrigger) Stop() error {
+func (t *Trigger) Stop() error {
 
 	//unsubscribe from topics
 	for _, handler := range t.handlers {

--- a/trigger/mqtt/trigger_test.go
+++ b/trigger/mqtt/trigger_test.go
@@ -40,7 +40,7 @@ const testConfig string = `{
 
 func TestTrigger_Register(t *testing.T) {
 
-	ref := support.GetRef(&MqttTrigger{})
+	ref := support.GetRef(&Trigger{})
 	f := trigger.GetFactory(ref)
 	assert.NotNil(t, f)
 }


### PR DESCRIPTION
Standardize on Activity & Trigger as names of the contrib implmentations