### PR TITLE
Feature topic

### DIFF
--- a/activity/mqtt/README.md
+++ b/activity/mqtt/README.md
@@ -26,8 +26,8 @@ flogo install github.com/project-flogo/edge-contrib/activity/mqtt
 | topic        | string | The topic to publish to - ***REQUIRED***
 | qos          | int    | The quality of service
 | sslConfig    | object | SSL configuration
- 
- #### *sslConfig* Object: 
+
+ #### *sslConfig* Object:
  | Property      | Type   | Description
  |:---           | :---   | :---     
  | skipVerify    | bool   | Skip SSL validation, defaults to true
@@ -35,15 +35,16 @@ flogo install github.com/project-flogo/edge-contrib/activity/mqtt
  | caFile        | string | The path to PEM encoded root certificates file
  | certFile      | string | The path to PEM encoded client certificate
  | keyFile       | string | The path to PEM encoded client key
- 
- *Note: used if broker URI is ssl*
- 
-### Input: 
 
-| Name    | Type   | Description
-| :---    | :---   | :---
-| message | string | The message to send  
-    
+ *Note: used if broker URI is ssl*
+
+### Input:
+
+| Name        | Type   | Description
+| :---        | :---   | :---
+| message     | string | The message to send  
+| topicParams | params | The topic parameters
+
 ### Output:
 
 | Name  | Type   | Description

--- a/activity/mqtt/README.md
+++ b/activity/mqtt/README.md
@@ -38,6 +38,9 @@ flogo install github.com/project-flogo/edge-contrib/activity/mqtt
 
  *Note: used if broker URI is ssl*
 
+#### Topics
+MQTT wildcard syntax is supported. For example if the topic is '/x/+/y/#' then '+' will be substituted with the value stored in `topicParams` `input` key '0' and '#' with key '1'. This can also be done with names: '/x/+param1/y/#param2'. The keys used for substitution are now 'param1' and 'param2'
+
 ### Input:
 
 | Name        | Type   | Description

--- a/activity/mqtt/README.md
+++ b/activity/mqtt/README.md
@@ -39,7 +39,7 @@ flogo install github.com/project-flogo/edge-contrib/activity/mqtt
  *Note: used if broker URI is ssl*
 
 #### Topics
-MQTT wildcard syntax is supported. For example if the topic is '/x/+/y/#' then '+' will be substituted with the value stored in `topicParams` `input` key '0' and '#' with key '1'. This can also be done with names: '/x/+param1/y/#param2'. The keys used for substitution are now 'param1' and 'param2'
+A substitution syntax is supported. For example if the topic is '/x/:/y/:' then the first ':' will be substituted with the value stored in `topicParams` `input` key '0' and the second ':' with key '1'. This can also be done with names: '/x/:param1/y/:param2'. The keys used for substitution are now 'param1' and 'param2'
 
 ### Input:
 

--- a/activity/mqtt/activity_test.go
+++ b/activity/mqtt/activity_test.go
@@ -43,17 +43,17 @@ func TestParseTopic(t *testing.T) {
 		parsed := ParseTopic(input)
 		assert.Equal(t, parsed.String(params), output)
 	}
-	test("/a/+x/b/#y", "/a/test/b/j/k", map[string]string{"x": "test", "y": "j/k"})
-	test("/a/+/b/#", "/a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
-	test("a/+/b/#", "a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
-	test("a/+/b", "a/test/b", map[string]string{"0": "test"})
-	test("a/+/b/", "a/test/b/", map[string]string{"0": "test"})
+	test("/a/:x/b/:y", "/a/test/b/j/k", map[string]string{"x": "test", "y": "j/k"})
+	test("/a/:/b/:", "/a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
+	test("a/:/b/:", "a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
+	test("a/:/b", "a/test/b", map[string]string{"0": "test"})
+	test("a/:/b/", "a/test/b/", map[string]string{"0": "test"})
 	test("", "", map[string]string{})
-	test("+", "test", map[string]string{"0": "test"})
-	test("#", "test", map[string]string{"0": "test"})
+	test(":", "test", map[string]string{"0": "test"})
+	test(":", "test", map[string]string{"0": "test"})
 	test("/", "/", map[string]string{})
-	test("/+", "/test", map[string]string{"0": "test"})
-	test("/#", "/test", map[string]string{"0": "test"})
+	test("/:", "/test", map[string]string{"0": "test"})
+	test("/:", "/test", map[string]string{"0": "test"})
 	test("/a/b", "/a/b", map[string]string{})
 }
 
@@ -86,7 +86,7 @@ func TestEval(t *testing.T) {
 	settings := Settings{
 		Broker: "tcp://localhost:1883",
 		Id:     "TestX",
-		Topic:  "/x/+a/y/#b",
+		Topic:  "/x/:a/y/:b",
 	}
 	init := test.NewActivityInitContext(settings, nil)
 	act, err := New(init)

--- a/activity/mqtt/activity_test.go
+++ b/activity/mqtt/activity_test.go
@@ -1,11 +1,61 @@
 package mqtt
 
 import (
+	"net"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/project-flogo/core/activity"
-	"github.com/stretchr/testify/assert"
+	"github.com/project-flogo/core/support/test"
 )
+
+func Pour(port string) {
+	for {
+		conn, _ := net.Dial("tcp", net.JoinHostPort("", port))
+		if conn != nil {
+			conn.Close()
+			break
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	command := exec.Command("docker", "start", "mqtt")
+	err := command.Run()
+	if err != nil {
+		command := exec.Command("docker", "run", "-p", "1883:1883", "-p", "9001:9001", "--name", "mqtt", "-d", "eclipse-mosquitto")
+		err := command.Run()
+		if err != nil {
+			panic(err)
+		}
+	}
+	Pour("1883")
+	os.Exit(m.Run())
+}
+
+func TestParseTopic(t *testing.T) {
+	test := func(input, output string, params map[string]string) {
+		parsed := ParseTopic(input)
+		assert.Equal(t, parsed.String(params), output)
+	}
+	test("/a/+x/b/#y", "/a/test/b/j/k", map[string]string{"x": "test", "y": "j/k"})
+	test("/a/+/b/#", "/a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
+	test("a/+/b/#", "a/test/b/j/k", map[string]string{"0": "test", "1": "j/k"})
+	test("a/+/b", "a/test/b", map[string]string{"0": "test"})
+	test("a/+/b/", "a/test/b/", map[string]string{"0": "test"})
+	test("", "", map[string]string{})
+	test("+", "test", map[string]string{"0": "test"})
+	test("#", "test", map[string]string{"0": "test"})
+	test("/", "/", map[string]string{})
+	test("/+", "/test", map[string]string{"0": "test"})
+	test("/#", "/test", map[string]string{"0": "test"})
+	test("/a/b", "/a/b", map[string]string{})
+}
 
 func TestRegister(t *testing.T) {
 
@@ -13,4 +63,44 @@ func TestRegister(t *testing.T) {
 	act := activity.Get(ref)
 
 	assert.NotNil(t, act)
+}
+
+func TestEval(t *testing.T) {
+	options := mqtt.NewClientOptions()
+	options.AddBroker("tcp://localhost:1883")
+	options.SetClientID("TestAbc123")
+	client := mqtt.NewClient(options)
+	token := client.Connect()
+	token.Wait()
+	assert.Nil(t, token.Error())
+	fini := make(chan bool, 1)
+	token = client.Subscribe("/x/+/y/#", 0, func(client mqtt.Client, message mqtt.Message) {
+		topic, payload := message.Topic(), string(message.Payload())
+		assert.Equal(t, `{"message": "hello world"}`, payload)
+		assert.Equal(t, "/x/test/y/j/k", topic)
+		fini <- true
+	})
+	token.Wait()
+	assert.Nil(t, token.Error())
+
+	settings := Settings{
+		Broker: "tcp://localhost:1883",
+		Id:     "TestX",
+		Topic:  "/x/+a/y/#b",
+	}
+	init := test.NewActivityInitContext(settings, nil)
+	act, err := New(init)
+	assert.Nil(t, err)
+	context := test.NewActivityContext(activityMd)
+	context.SetInput("message", `{"message": "hello world"}`)
+	context.SetInput("topicParams", map[string]string{"a": "test", "b": "j/k"})
+	done, err := act.Eval(context)
+	assert.True(t, done)
+	assert.Nil(t, err)
+
+	select {
+	case <-fini:
+	case <-time.Tick(time.Second):
+		t.Fatal("didn't get message in time")
+	}
 }

--- a/activity/mqtt/descriptor.json
+++ b/activity/mqtt/descriptor.json
@@ -89,6 +89,11 @@
       "name": "message",
       "type": "string",
       "description": "The message to send"
+    },
+    {
+      "name": "topicParams",
+      "type": "params",
+      "description": "The topic parameters"
     }
   ],
   "output": [

--- a/activity/mqtt/go.sum
+++ b/activity/mqtt/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=

--- a/activity/mqtt/metadata.go
+++ b/activity/mqtt/metadata.go
@@ -1,19 +1,24 @@
 package mqtt
 
+import (
+	"github.com/project-flogo/core/data/coerce"
+)
+
 type Settings struct {
 	Broker       string                 `md:"broker,required"` // The broker URL
-	Id           string                 `md:"id,required"`    // The id of client
-	Username     string                 `md:"username"`       // The user's name
-	Password     string                 `md:"password"`       // The user's password
-	Store        string                 `md:"store"`          // The store for message persistence
-	CleanSession bool                   `md:"cleanSession"`   // Clean session flag
-	Topic        string                 `md:"topic,required"` // The topic to publish to
-	Qos          int                    `md:"qos"`            // The Quality of Service
-	SSLConfig    map[string]interface{} `md:"sslConfig"`      // SSL Configuration
+	Id           string                 `md:"id,required"`     // The id of client
+	Username     string                 `md:"username"`        // The user's name
+	Password     string                 `md:"password"`        // The user's password
+	Store        string                 `md:"store"`           // The store for message persistence
+	CleanSession bool                   `md:"cleanSession"`    // Clean session flag
+	Topic        string                 `md:"topic,required"`  // The topic to publish to
+	Qos          int                    `md:"qos"`             // The Quality of Service
+	SSLConfig    map[string]interface{} `md:"sslConfig"`       // SSL Configuration
 }
 
 type Input struct {
-	Message interface{} `md:"message"` // The message to send
+	Message     interface{}       `md:"message"`     // The message to send
+	TopicParams map[string]string `md:"topicParams"` // The topic parameters
 }
 
 type Output struct {
@@ -22,12 +27,18 @@ type Output struct {
 
 func (i *Input) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"message": i.Message,
+		"message":     i.Message,
+		"topicParams": i.TopicParams,
 	}
 }
 
 func (i *Input) FromMap(values map[string]interface{}) error {
+	var err error
 	i.Message, _ = values["message"]
+	i.TopicParams, err = coerce.ToParams(values["topicParams"])
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/trigger/mqtt/README.md
+++ b/trigger/mqtt/README.md
@@ -18,7 +18,7 @@ flogo install github.com/project-flogo/edge-contrib/trigger/mqtt
 | Name          | Type   | Description
 | :---          | :---   | :---
 | broker        | string | The broker URL - ***REQUIRED***
-| id            | string | The id of client - ***REQUIRED*** 
+| id            | string | The id of client - ***REQUIRED***
 | username      | string | The user's name
 | password      | string | The user's password
 | store         | string | The store for message persistence
@@ -26,8 +26,8 @@ flogo install github.com/project-flogo/edge-contrib/trigger/mqtt
 | keepAlive     | int    | Keep Alive time in seconds
 | autoReconnect | bool   | Enable Auto-Reconnect
 | sslConfig     | object | SSL configuration
- 
- #### *sslConfig* Object: 
+
+ #### *sslConfig* Object:
  | Property      | Type   | Description
  |:---           | :---   | :---     
  | skipVerify    | bool   | Skip SSL validation, defaults to true
@@ -35,9 +35,9 @@ flogo install github.com/project-flogo/edge-contrib/trigger/mqtt
  | caFile        | string | The path to PEM encoded root certificates file
  | certFile      | string | The path to PEM encoded client certificate
  | keyFile       | string | The path to PEM encoded client key
- 
+
  *Note: used if broker URI is ssl*
- 
+
 ### Handler Settings
 | Name       | Type   | Description
 | :---       | :---   | :---
@@ -45,12 +45,13 @@ flogo install github.com/project-flogo/edge-contrib/trigger/mqtt
 | replyTopic | string | The topic to reply on   
 | qos        | int    | The Quality of Service
 
-### Output: 
+### Output:
 
-| Name    | Type   | Description
-| :---    | :---   | :---
-| message | string | The message recieved
-    
+| Name        | Type   | Description
+| :---        | :---   | :---
+| message     | string | The message received
+| topicParams | params | The topic parameters
+
 ### Reply:
 
 | Name  | Type   | Description

--- a/trigger/mqtt/README.md
+++ b/trigger/mqtt/README.md
@@ -53,6 +53,7 @@ MQTT wildcard syntax is supported. For example if the topic is '/x/+/y/#' then t
 | Name        | Type   | Description
 | :---        | :---   | :---
 | message     | string | The message received
+| topic       | string | The MQTT topic
 | topicParams | params | The topic parameters
 
 ### Reply:

--- a/trigger/mqtt/README.md
+++ b/trigger/mqtt/README.md
@@ -45,6 +45,9 @@ flogo install github.com/project-flogo/edge-contrib/trigger/mqtt
 | replyTopic | string | The topic to reply on   
 | qos        | int    | The Quality of Service
 
+#### Topics
+MQTT wildcard syntax is supported. For example if the topic is '/x/+/y/#' then the `topicParams` `output` will be populated with the wildcard values. The first wildcard will be in `topicParams` with key '0' and the second with key '1'. Topic wildcards can also be given a name: '/x/+param1/y/#param2'. Then the names 'param1' and 'param2' can be used to access the wildcards in the `topicParams` `output`.
+
 ### Output:
 
 | Name        | Type   | Description

--- a/trigger/mqtt/descriptor.json
+++ b/trigger/mqtt/descriptor.json
@@ -87,7 +87,12 @@
       {
         "name": "message",
         "type": "string",
-        "description": "The message recieved"
+        "description": "The message received"
+      },
+      {
+        "name": "topicParams",
+        "type": "params",
+        "description": "The topic parameters"
       }
     ],
     "reply": [
@@ -113,4 +118,3 @@
       ]
     }
   }
-  

--- a/trigger/mqtt/go.sum
+++ b/trigger/mqtt/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=

--- a/trigger/mqtt/metadata.go
+++ b/trigger/mqtt/metadata.go
@@ -23,7 +23,8 @@ type HandlerSettings struct {
 }
 
 type Output struct {
-	Message string `md:"message"` // The message recieved
+	Message     string            `md:"message"`     // The message recieved
+	TopicParams map[string]string `md:"topicParams"` // The topic parameters
 }
 
 type Reply struct {
@@ -32,7 +33,8 @@ type Reply struct {
 
 func (o *Output) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"message": o.Message,
+		"message":     o.Message,
+		"topicParams": o.TopicParams,
 	}
 }
 
@@ -40,6 +42,10 @@ func (o *Output) FromMap(values map[string]interface{}) error {
 
 	var err error
 	o.Message, err = coerce.ToString(values["message"])
+	if err != nil {
+		return err
+	}
+	o.TopicParams, err = coerce.ToParams(values["topicParams"])
 	if err != nil {
 		return err
 	}

--- a/trigger/mqtt/metadata.go
+++ b/trigger/mqtt/metadata.go
@@ -24,6 +24,7 @@ type HandlerSettings struct {
 
 type Output struct {
 	Message     string            `md:"message"`     // The message recieved
+	Topic       string            `md:"topic"`       // The MQTT topic
 	TopicParams map[string]string `md:"topicParams"` // The topic parameters
 }
 
@@ -34,6 +35,7 @@ type Reply struct {
 func (o *Output) ToMap() map[string]interface{} {
 	return map[string]interface{}{
 		"message":     o.Message,
+		"topic":       o.Topic,
 		"topicParams": o.TopicParams,
 	}
 }
@@ -42,6 +44,10 @@ func (o *Output) FromMap(values map[string]interface{}) error {
 
 	var err error
 	o.Message, err = coerce.ToString(values["message"])
+	if err != nil {
+		return err
+	}
+	o.Topic, err = coerce.ToString(values["topic"])
 	if err != nil {
 		return err
 	}

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -297,7 +297,7 @@ func (t *Trigger) getHanlder(handler *clientHandler, parsed Topic) func(mqtt.Cli
 
 		t.logger.Debugf("Topic[%s] - Payload Recieved: %s", topic, payload)
 
-		result, err := runHandler(handler.handler, payload, params)
+		result, err := runHandler(handler.handler, payload, topic, params)
 		if err != nil {
 			t.logger.Error("Error handling message: %v", err)
 			return
@@ -328,11 +328,12 @@ func (t *Trigger) getHanlder(handler *clientHandler, parsed Topic) func(mqtt.Cli
 }
 
 // RunHandler runs the handler and associated action
-func runHandler(handler trigger.Handler, payload string, params map[string]string) (map[string]interface{}, error) {
-
-	out := &Output{}
-	out.Message = payload
-	out.TopicParams = params
+func runHandler(handler trigger.Handler, payload, topic string, params map[string]string) (map[string]interface{}, error) {
+	out := &Output{
+		Message:     payload,
+		Topic:       topic,
+		TopicParams: params,
+	}
 
 	results, err := handler.Handle(context.Background(), out)
 	if err != nil {

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -277,7 +277,8 @@ func (t *Trigger) Stop() error {
 
 	//unsubscribe from topics
 	for _, handler := range t.handlers {
-		t.logger.Debug("Unsubscribing from topic: ", handler.settings.Topic)
+		parsed := ParseTopic(handler.settings.Topic)
+		t.logger.Debug("Unsubscribing from topic: ", parsed.String())
 		if token := t.client.Unsubscribe(handler.settings.Topic); token.Wait() && token.Error() != nil {
 			t.logger.Errorf("Error unsubscribing from topic %s: %s", handler.settings.Topic, token.Error())
 		}

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -277,10 +277,10 @@ func (t *Trigger) Stop() error {
 
 	//unsubscribe from topics
 	for _, handler := range t.handlers {
-		parsed := ParseTopic(handler.settings.Topic)
-		t.logger.Debug("Unsubscribing from topic: ", parsed.String())
-		if token := t.client.Unsubscribe(handler.settings.Topic); token.Wait() && token.Error() != nil {
-			t.logger.Errorf("Error unsubscribing from topic %s: %s", handler.settings.Topic, token.Error())
+		topic := ParseTopic(handler.settings.Topic).String()
+		t.logger.Debug("Unsubscribing from topic: ", topic)
+		if token := t.client.Unsubscribe(topic); token.Wait() && token.Error() != nil {
+			t.logger.Errorf("Error unsubscribing from topic %s: %s", topic, token.Error())
 		}
 	}
 

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,118 @@ var triggerMd = trigger.NewMetadata(&Settings{}, &HandlerSettings{}, &Output{})
 
 func init() {
 	_ = trigger.Register(&Trigger{}, &Factory{})
+}
+
+// TokenType is a type of token
+type TokenType int
+
+const (
+	// Literal is a literal token type
+	Literal TokenType = iota
+	// SingleLevel is a single level wildcard
+	SingleLevel
+	// MultiLevel is a multi level wildcard
+	MultiLevel
+)
+
+// Token is a MQTT topic token
+type Token struct {
+	TokenType TokenType
+	Token     string
+}
+
+// Topic is a parsed topic
+type Topic []Token
+
+// ParseTopic parses the topic
+func ParseTopic(topic string) Topic {
+	var parsed Topic
+	parts, index := strings.Split(topic, "/"), 0
+	for _, part := range parts {
+		if strings.HasPrefix(part, "+") {
+			token := strings.TrimPrefix(part, "+")
+			if token == "" {
+				token = strconv.Itoa(index)
+				index++
+			}
+			parsed = append(parsed, Token{
+				TokenType: SingleLevel,
+				Token:     token,
+			})
+		} else if strings.HasPrefix(part, "#") {
+			token := strings.TrimPrefix(part, "#")
+			if token == "" {
+				token = strconv.Itoa(index)
+				index++
+			}
+			parsed = append(parsed, Token{
+				TokenType: MultiLevel,
+				Token:     token,
+			})
+		} else {
+			parsed = append(parsed, Token{
+				TokenType: Literal,
+				Token:     part,
+			})
+		}
+	}
+	return parsed
+}
+
+// Match matches the topic with an input topic
+func (t Topic) Match(input Topic) map[string]string {
+	output, i := make(map[string]string), 0
+MATCHER:
+	for _, token := range t {
+		switch token.TokenType {
+		case Literal:
+			if i > len(input) {
+				break MATCHER
+			}
+			if token.Token != input[i].Token {
+				break MATCHER
+			}
+		case SingleLevel:
+			if i >= len(input) {
+				output[token.Token] = ""
+				break MATCHER
+			}
+			output[token.Token] = input[i].Token
+		case MultiLevel:
+			if i >= len(input) {
+				output[token.Token] = ""
+				break MATCHER
+			}
+			levels, sep := "", ""
+			for _, level := range input[i:] {
+				levels += sep + level.Token
+				sep = "/"
+				i++
+			}
+			output[token.Token] = levels
+			break MATCHER
+		}
+		i++
+	}
+	return output
+}
+
+func (t Topic) String() string {
+	output := strings.Builder{}
+	for i, token := range t {
+		if i > 0 {
+			output.WriteString("/")
+		}
+		switch token.TokenType {
+		case Literal:
+			output.WriteString(token.Token)
+		case SingleLevel:
+			output.WriteString("+")
+		case MultiLevel:
+			output.WriteString("#")
+		}
+	}
+	return output.String()
 }
 
 // Trigger is simple MQTT trigger
@@ -146,8 +259,8 @@ func (t *Trigger) Start() error {
 	t.client = client
 
 	for _, handler := range t.handlers {
-
-		if token := client.Subscribe(handler.settings.Topic, byte(handler.settings.Qos), t.getHanlder(handler)); token.Wait() && token.Error() != nil {
+		parsed := ParseTopic(handler.settings.Topic)
+		if token := client.Subscribe(parsed.String(), byte(handler.settings.Qos), t.getHanlder(handler, parsed)); token.Wait() && token.Error() != nil {
 			t.logger.Errorf("Error subscribing to topic %s: %s", handler.settings.Topic, token.Error())
 			return token.Error()
 		}
@@ -174,15 +287,16 @@ func (t *Trigger) Stop() error {
 	return nil
 }
 
-func (t *Trigger) getHanlder(handler *clientHandler) func(mqtt.Client, mqtt.Message) {
+func (t *Trigger) getHanlder(handler *clientHandler, parsed Topic) func(mqtt.Client, mqtt.Message) {
 	return func(client mqtt.Client, msg mqtt.Message) {
 		topic := msg.Topic()
 		qos := msg.Qos()
 		payload := string(msg.Payload())
+		params := parsed.Match(ParseTopic(topic))
 
 		t.logger.Debugf("Topic[%s] - Payload Recieved: %s", topic, payload)
 
-		result, err := runHandler(handler.handler, payload)
+		result, err := runHandler(handler.handler, payload, params)
 		if err != nil {
 			t.logger.Error("Error handling message: %v", err)
 			return
@@ -213,10 +327,11 @@ func (t *Trigger) getHanlder(handler *clientHandler) func(mqtt.Client, mqtt.Mess
 }
 
 // RunHandler runs the handler and associated action
-func runHandler(handler trigger.Handler, payload string) (map[string]interface{}, error) {
+func runHandler(handler trigger.Handler, payload string, params map[string]string) (map[string]interface{}, error) {
 
 	out := &Output{}
 	out.Message = payload
+	out.TopicParams = params
 
 	results, err := handler.Handle(context.Background(), out)
 	if err != nil {

--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -114,6 +114,7 @@ MATCHER:
 	return output
 }
 
+// String generates a string for the topic
 func (t Topic) String() string {
 	output := strings.Builder{}
 	for i, token := range t {

--- a/trigger/mqtt/trigger_test.go
+++ b/trigger/mqtt/trigger_test.go
@@ -119,7 +119,7 @@ const testConfigLocalgetHandler string = `{
 func TestParseTopic(t *testing.T) {
 	test := func(input, output string) {
 		parsed := ParseTopic(input)
-		assert.Equal(t, parsed.String(), output)
+		assert.Equal(t, output, parsed.String())
 	}
 	test("/a/+x/b/#y", "/a/+/b/#")
 	test("/a/+/b/#", "/a/+/b/#")
@@ -139,7 +139,7 @@ func TestTopic_Match(t *testing.T) {
 		parsed, input := ParseTopic(match), ParseTopic(in)
 		found := parsed.Match(input)
 		for key, value := range params {
-			assert.Equal(t, value, found[key])
+			assert.Equal(t, found[key], value)
 		}
 	}
 	test("/a/+x/b/#y", "/a/x/b/y/z/", map[string]string{"x": "x", "y": "y/z/"})

--- a/trigger/mqtt/trigger_test.go
+++ b/trigger/mqtt/trigger_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
@@ -215,7 +216,11 @@ func TestRestTrigger_getHanlder(t *testing.T) {
 	token = client.Publish("test/a/b/req/c/d", 0, true, []byte(`{"message": "hello world"}`))
 	token.Wait()
 	assert.Nil(t, token.Error())
-	<-done
+	select {
+	case <-done:
+	case <-time.Tick(time.Second):
+		t.Fatal("didn't get message in time")
+	}
 	client.Disconnect(50)
 
 	err = trg.Stop()

--- a/trigger/mqtt/trigger_test.go
+++ b/trigger/mqtt/trigger_test.go
@@ -2,7 +2,12 @@ package mqtt
 
 import (
 	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
 	"testing"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/support"
@@ -10,6 +15,30 @@ import (
 	"github.com/project-flogo/core/trigger"
 	"github.com/stretchr/testify/assert"
 )
+
+func Pour(port string) {
+	for {
+		conn, _ := net.Dial("tcp", net.JoinHostPort("", port))
+		if conn != nil {
+			conn.Close()
+			break
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	command := exec.Command("docker", "start", "mqtt")
+	err := command.Run()
+	if err != nil {
+		command := exec.Command("docker", "run", "-p", "1883:1883", "-p", "9001:9001", "--name", "mqtt", "-d", "eclipse-mosquitto")
+		err := command.Run()
+		if err != nil {
+			panic(err)
+		}
+	}
+	Pour("1883")
+	os.Exit(m.Run())
+}
 
 const testConfig string = `{
 	"id": "trigger-mqtt",
@@ -38,6 +67,94 @@ const testConfig string = `{
 	]
   }`
 
+const testConfigLocal string = `{
+		"id": "trigger-mqtt",
+		"ref": "github.com/project-flogo/device-contrib/trigger/mqtt",
+		"settings": {
+			"autoreconnect": true,
+	        "broker": "tcp://localhost:1883",
+	        "cleansess": false,
+	        "enableTLS": false,
+					"id": "FlogoTest237123",
+	        "keepalive": 30,
+	        "store": ":memory:"
+	    },
+		"handlers": [
+		  {
+			"settings": {
+				"topic": "control/+/+/req/#"
+			},
+			"action" : {
+			  "id": "dummy"
+			}
+		  }
+		]
+	  }`
+
+const testConfigLocalgetHandler string = `{
+				"id": "trigger1-mqtt",
+				"ref": "github.com/project-flogo/device-contrib/trigger/mqtt",
+				"settings": {
+					"autoreconnect": true,
+			        "broker": "tcp://localhost:1883",
+			        "cleansess": false,
+			        "enableTLS": false,
+							"id": "FlogoTest2371231",
+			        "keepalive": 30,
+			        "store": ":memory:"
+			    },
+				"handlers": [
+				  {
+					"settings": {
+						"topic": "test/+/+/req/#"
+					},
+					"action" : {
+					  "id": "dummyTest"
+					}
+				  }
+				]
+			  }`
+
+func TestParseTopic(t *testing.T) {
+	test := func(input, output string) {
+		parsed := ParseTopic(input)
+		assert.Equal(t, parsed.String(), output)
+	}
+	test("/a/+x/b/#y", "/a/+/b/#")
+	test("/a/+/b/#", "/a/+/b/#")
+	test("a/+/b/#", "a/+/b/#")
+	test("a/+/b", "a/+/b")
+	test("a/+/b/", "a/+/b/")
+	test("", "")
+	test("+", "+")
+	test("#", "#")
+	test("/", "/")
+	test("/+", "/+")
+	test("/#", "/#")
+}
+
+func TestTopic_Match(t *testing.T) {
+	test := func(match, in string, params map[string]string) {
+		parsed, input := ParseTopic(match), ParseTopic(in)
+		found := parsed.Match(input)
+		for key, value := range params {
+			assert.Equal(t, value, found[key])
+		}
+	}
+	test("/a/+x/b/#y", "/a/x/b/y/z/", map[string]string{"x": "x", "y": "y/z/"})
+	test("a/+x/b/#y", "a/x/b/y/z/", map[string]string{"x": "x", "y": "y/z/"})
+	test("/a/+x/b/#y", "/a/x/b/y/z", map[string]string{"x": "x", "y": "y/z"})
+	test("/a/+x/b/#y", "/a/x/b/y", map[string]string{"x": "x", "y": "y"})
+	test("/a/+x/b/#y", "/a/x/b", map[string]string{"x": "x", "y": ""})
+	test("/a/+x/b/", "/a/x/b/", map[string]string{"x": "x"})
+	test("/a/+x/b", "/a/x/b", map[string]string{"x": "x"})
+	test("/a/+x", "/a/x", map[string]string{"x": "x"})
+	test("/+x", "/x/gah", map[string]string{"x": "x"})
+	test("/#x", "/x/gah", map[string]string{"x": "x/gah"})
+	test("+x", "x/gah", map[string]string{"x": "x"})
+	test("#x", "x/gah", map[string]string{"x": "x/gah"})
+}
+
 func TestTrigger_Register(t *testing.T) {
 
 	ref := support.GetRef(&Trigger{})
@@ -50,19 +167,57 @@ func TestRestTrigger_Initialize(t *testing.T) {
 	f := &Factory{}
 
 	config := &trigger.Config{}
-	err := json.Unmarshal([]byte(testConfig), config)
+	err := json.Unmarshal([]byte(testConfigLocal), config)
 	assert.Nil(t, err)
 
 	actions := map[string]action.Action{"dummy": test.NewDummyAction(func() {
 	})}
 
 	trg, err := test.InitTrigger(f, config, actions)
-
 	assert.Nil(t, err)
 	assert.NotNil(t, trg)
-	err = trg.Start()
-	
-	for {
 
-	}
+	err = trg.Start()
+	assert.Nil(t, err)
+
+	err = trg.Stop()
+	assert.Nil(t, err)
+}
+
+func TestRestTrigger_getHanlder(t *testing.T) {
+
+	f := &Factory{}
+
+	config := &trigger.Config{}
+	err := json.Unmarshal([]byte(testConfigLocalgetHandler), config)
+	assert.Nil(t, err)
+
+	done := make(chan bool, 1)
+	actions := map[string]action.Action{"dummyTest": test.NewDummyAction(func() {
+		done <- true
+	})}
+
+	trg, err := test.InitTrigger(f, config, actions)
+	assert.Nil(t, err)
+	assert.NotNil(t, trg)
+
+	err = trg.Start()
+	assert.Nil(t, err)
+
+	options := mqtt.NewClientOptions()
+	options.AddBroker("tcp://localhost:1883")
+	options.SetClientID("TestAbc123")
+	client := mqtt.NewClient(options)
+	token := client.Connect()
+	token.Wait()
+	assert.Nil(t, token.Error())
+
+	token = client.Publish("test/a/b/req/c/d", 0, true, []byte(`{"message": "hello world"}`))
+	token.Wait()
+	assert.Nil(t, token.Error())
+	<-done
+	client.Disconnect(50)
+
+	err = trg.Stop()
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Adds support for topic parameters. For triggers, the output topicParams will be populated with any topic wildcard values. For activities, the input topicParams will be used to set the wildcards in the topic. Topics can take the form of '/x/+/y/#' in which case the topicParams are keyed: '0', '1', etc... For topics of the form '/x/+param1/y/#param2' the keys are 'param1' and 'param2'.